### PR TITLE
Allow specifying args to the mocha/npm test via 'cargo test' 

### DIFF
--- a/speculos-wrapper
+++ b/speculos-wrapper
@@ -1,19 +1,35 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 echo "Speculos Wrapper called with $*"
 
-for last in "$@"; do :; done
+# Specify args for mocha / 'npm test' like this
+# cargo test --test ts-tests --target=nanos.json -- --mocha-args="--grep 'provides a public key'"
+# cargo test --test ts-tests --target=nanos.json -- --mocha-args="--timeout 30000"
+MOCHA_ARGS=""
 
-case $last in
-  *ts_tests*)
-    echo "Matched *ts_tests*"
+run_ts_tests() {
     speculos "$@" --display headless &
     SPECULOS=$!
     until wget -O/dev/null -o/dev/null http://localhost:5000/; do sleep 0.1; done;
     cd ../ts-tests;
     if ! [ -d "node_modules" ] ; then npm install; fi
-    npm test
+    echo $MOCHA_ARGS | xargs npm test --
     kill $SPECULOS
+}
+
+last="${@:$#}"
+
+case $last in
+  --mocha-args=*)
+    echo "Matched --mocha-args=*"
+    MOCHA_ARGS=${last:13} # strip --mocha-args=
+    echo "Passing following args to npm test: $MOCHA_ARGS"
+    # Pass all args, except the last, to the speculos
+    run_ts_tests "${@:1:$#-1}"
+    ;;
+  *ts_tests*)
+    echo "Matched *ts_tests*"
+    run_ts_tests "$@"
     ;;
   */deps/*) # Assume anything in the deps directory is a test, not the full app.
     echo "Matched *tests*"


### PR DESCRIPTION
Relevant commit: https://github.com/alamgu/ledger-rust-app/commit/e7e37dcf618a21013b14f17c5a094963b2b655c2

Usage:
```
cargo test --test ts-tests --target=nanos.json -- --mocha-args="--grep 'provides a public key'"
cargo test --test ts-tests --target=nanos.json -- --mocha-args="--timeout 30000"
```