### PR TITLE
Decouple dev shell from crate2nix stuff

### DIFF
--- a/dep/ledger-nanos-sdk/default.nix
+++ b/dep/ledger-nanos-sdk/default.nix
@@ -1,0 +1,2 @@
+# DO NOT HAND-EDIT THIS FILE
+import (import ./thunk.nix)

--- a/dep/ledger-nanos-sdk/github.json
+++ b/dep/ledger-nanos-sdk/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "alamgu",
+  "repo": "ledger-nanos-sdk",
+  "branch": "relocating-loader-w-fixes",
+  "private": false,
+  "rev": "27c4df41a062cfc5382ef733a7f26aff10d6c6f7",
+  "sha256": "0zg82w7xj66caxw6zf1qslz5znfhpjl16ajjc1dn7f5m9h4lfg7c"
+}

--- a/dep/ledger-nanos-sdk/thunk.nix
+++ b/dep/ledger-nanos-sdk/thunk.nix
@@ -1,0 +1,9 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+  json = builtins.fromJSON (builtins.readFile ./github.json);
+in fetch json


### PR DESCRIPTION
This allows one to enter the shell even if the `Cargo.toml` or `crate-hashes.json` is invalid or out of sync.

The cost if that we now pin the SDK in a thunk *and* the lock file, but it has been requested that we put the script logic in `cargo-ledger` instead, which would mean this duplication goes away.