### PR TITLE
[test]

### DIFF
--- a/ragger-tests/test_pubkey_cmd.py
+++ b/ragger-tests/test_pubkey_cmd.py
@@ -25,18 +25,9 @@ def test_get_public_key_confirm_accepted(backend, scenario_navigator, firmware, 
     client = BoilerplateCommandSender(backend, use_block_protocol=True)
     path = "m/44'/535348'/0'"
 
-    def nav_task():
-        scenario_navigator.address_review_approve()
+    _, public_key, _, _ = client.get_public_key_with_confirmation(scenario_navigator, path=path)
+    assert public_key.hex() == "19e2fea57e82293b4fee8120d934f0c5a4907198f8df29e9a153cfd7d9383488"
 
-    def apdu_task():
-        return client.get_public_key_with_confirmation(path=path)
-
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        future = executor.submit(apdu_task)
-        time.sleep(2)
-        executor.submit(nav_task)
-        _, public_key, _, _ = future.result()
-        assert public_key.hex() == "19e2fea57e82293b4fee8120d934f0c5a4907198f8df29e9a153cfd7d9383488"
 
 # # In this test we check that the GET_PUBLIC_KEY in confirmation mode replies an error if the user refuses
 # def test_get_public_key_confirm_refused(backend, scenario_navigator):
@@ -50,4 +41,3 @@ def test_get_public_key_confirm_accepted(backend, scenario_navigator, firmware, 
 #     # Assert that we have received a refusal
 #     assert e.value.status == Errors.SW_DENY
 #     assert len(e.value.data) == 0
-


### PR DESCRIPTION
Quick hack to use only Ragger and not bothering with futures.

This requires to integrate the navigation inside the client.
I do this personally, as I think the client is aware of how the app behaves and can manage the screens (a method like `get_public_key_with_confirmation` ought to manage the confirmation itself, right?), and the tests are then smaller.
But the client becomes heavier and dealing with corner cases (testing cancellation or other scenarios) requires to add boilerplate arguments and conditions (again, heavier client).

A much more dubious pattern in this case is that, due to the block communication, the navigation is managed down to the exchange level, between requests and answers, with very non-generic step management ("_if I get the public key, I except 1 screen, then I validate, elif I sign a transaction, I except 2 screens changes, then I approve, elif..._").
High-level logic is entangled into low-level block management. That's not great.
There probably are ways to clean this a bit, but I fear that this can not be totally streamlined.

So I'd say that could be a valid choice for simple application, with few user interactions: maybe 3, 4 scenarios like that.